### PR TITLE
Fix for %r option to account for blank or local

### DIFF
--- a/tail_n_mail
+++ b/tail_n_mail
@@ -235,7 +235,7 @@ if (!$havepid and $arg{pglog} ne 'syslog') {
 $llp =~ s/%l/\\d+/;
 $llp =~ s/%u/[\\[\\w\\]]*/;
 $llp =~ s/%d/[\\[\\w\\]]*/;
-$llp =~ s/%r/.*\?/;
+$llp =~ s/%r/\\S*/;
 $llp =~ s/%h/\\S*/;
 
 if ($arg{pglog} eq 'syslog') {


### PR DESCRIPTION
On August 9th, I spoke with Greg Mullane on freenode irc about an issue I was having with the %r log line prefix option not accounting for it being empty or a local connection. Figured I'd take a try at fixing it. I tested this with a .tailnmailrc file containing 

log_line_prefix = '%t [%r] [%p]: [%l-1] user=%u,db=%d,'

And this as a test error:
2011-08-12 16:06:04 EDT [[local]] [11065]: [2-1] user=postgres,db=postgres,ecode=42P01: STATEMENT:  select testing from tailnmail where please_ignore = 'yes';

We then use 'ecode=' to have tail_n_mail filter out unwanted error codes. The odd format is to allow it to work with pgfouine as well. It found the above log line during a dryrun test. It also found it if the [local] text was removed from the %r position.
