### PR TITLE
allow dots in the user and database name of log_line_prefix

### DIFF
--- a/tail_n_mail
+++ b/tail_n_mail
@@ -255,8 +255,8 @@ if (!$havepid and $arg{pglog} ne 'syslog') {
     $llp = "()$llp";
 }
 $llp =~ s/%l/\\d+/;
-$llp =~ s/%u/[\\[\\w\\]]*/;
-$llp =~ s/%d/[\\[\\w\\]]*/;
+$llp =~ s/%u/[\\[\\w\\].]*/;
+$llp =~ s/%d/[\\[\\w\\].]*/;
 $llp =~ s/%r/\\S*/;
 $llp =~ s/%h/\\S*/;
 $llp =~ s/%a/\\S*/;


### PR DESCRIPTION
I am using domain names for my postgreSQL user and database names. For example "website.github.com" is valid for both.
