### PR TITLE
Changing SMTP library.

### DIFF
--- a/tail_n_mail
+++ b/tail_n_mail
@@ -2864,7 +2864,7 @@ sub send_smtp_email {
 
     my ($from_addr,$emails,$subject,$tempfile) = @_;
 
-    require Net::SMTP::SSL;
+    require Net::SMTP;
 
     ## Absorb any values set by rc files, and sanity check things
     my $mailserver = $opt{mailserver} || $arg{mailserver};
@@ -2883,11 +2883,12 @@ sub send_smtp_email {
 
     ## Attempt to connect to the server
     my $smtp;
-    if (not $smtp = Net::SMTP::SSL->new(
+    if (not $smtp = Net::SMTP->new(
         $mailserver,
         Port    => $mailport,
         Debug   => 0,
         Timeout => 30,
+        SSL     => 1
     )) {
         die qq{Failed to connect to mail server: $!};
     }


### PR DESCRIPTION
https://metacpan.org/pod/Net::SMTP::SSL
Net::SMTP itself has support for SMTP over SSL, and also for STARTTLS. Use Net::SMTP, not Net::SMTP::SSL.


Old library throw error:
*******************************************************************
 Using the default of SSL_verify_mode of SSL_VERIFY_NONE for client
 is deprecated! Please set SSL_verify_mode to SSL_VERIFY_PEER
 possibly with SSL_ca_file|SSL_ca_path for verification.
 If you really don't want to verify the certificate and keep the
 connection open to Man-In-The-Middle attacks please set
 SSL_verify_mode explicitly to SSL_VERIFY_NONE in your application.
*******************************************************************
  at /usr/bin/tail_n_mail.pl line 2886.




New dependency on Centos7:
rakudo-MIME-Base64.x86_64  perl-Authen-SASL.noarch